### PR TITLE
Fixes for strava auth changes #62

### DIFF
--- a/freezing/web/data.py
+++ b/freezing/web/data.py
@@ -57,7 +57,7 @@ def register_athlete(strava_athlete, token_dict):
 
     athlete.access_token = token_dict['access_token']
     athlete.refresh_token = token_dict['refresh_token']
-    athlete.expires_at = token_dict['exipires_at']
+    athlete.expires_at = token_dict['expires_at']
     meta.scoped_session().add(athlete)
     # We really shouldn't be committing here, since we want to disambiguate names after registering
     meta.scoped_session().commit()
@@ -76,7 +76,7 @@ def update_athlete_auth(strava_athlete, token_dict):
     if athlete is not None:
         athlete.access_token = token_dict['access_token']
         athlete.refresh_token = token_dict['refresh_token']
-        athlete.expires_at = token_dict['exipires_at']
+        athlete.expires_at = token_dict['expires_at']
         meta.scoped_session().add(athlete)
         meta.scoped_session().commit()
     return athlete

--- a/freezing/web/data.py
+++ b/freezing/web/data.py
@@ -38,7 +38,7 @@ class StravaClientForAthlete(Client):
         super(StravaClientForAthlete, self).__init__(access_token=athlete.access_token, rate_limit_requests=True)
 
 
-def register_athlete(strava_athlete, access_token):
+def register_athlete(strava_athlete, token_dict):
     """
     Ensure specified athlete is added to database, returns athlete orm.
 
@@ -55,11 +55,30 @@ def register_athlete(strava_athlete, access_token):
     athlete.display_name = strava_athlete.firstname
     athlete.profile_photo = strava_athlete.profile
 
-    athlete.access_token = access_token
+    athlete.access_token = token_dict['access_token']
+    athlete.refresh_token = token_dict['refresh_token']
+    athlete.expires_at = token_dict['exipires_at']
     meta.scoped_session().add(athlete)
     # We really shouldn't be committing here, since we want to disambiguate names after registering
     meta.scoped_session().commit()
 
+    return athlete
+
+
+def update_athlete_auth(strava_athlete, token_dict):
+    """
+    Update auth tokens for specified athlete
+
+    :return: The updated athlete model object, or None if no athlete found.
+    :rtype: :class:`bafs.orm.Athlete`
+    """
+    athlete = meta.scoped_session().query(Athlete).get(strava_athlete.id)
+    if athlete is not None:
+        athlete.access_token = token_dict['access_token']
+        athlete.refresh_token = token_dict['refresh_token']
+        athlete.expires_at = token_dict['exipires_at']
+        meta.scoped_session().add(athlete)
+        meta.scoped_session().commit()
     return athlete
 
 

--- a/freezing/web/data.py
+++ b/freezing/web/data.py
@@ -166,6 +166,8 @@ def register_athlete_team(strava_athlete, athlete_model):
     all_teams = config.COMPETITION_TEAMS
     log.info("Checking {0!r} against {1!r}".format(strava_athlete.clubs, all_teams))
     try:
+        if strava_athlete.clubs is None:
+            raise NoTeamsError()
         matches = [c for c in strava_athlete.clubs if c.id in all_teams]
         log.debug("Matched: {0!r}".format(matches))
         athlete_model.team = None

--- a/freezing/web/serialize.py
+++ b/freezing/web/serialize.py
@@ -10,6 +10,8 @@ class AthleteSchema(Schema):
     display_name = fields.String()
     team_id = fields.Integer(**optional)
     access_token = fields.String(**optional)
+    refresh_token = fields.String(**optional)
+    expires_at = fields.Integer()
     profile_photo = fields.String(**optional)
 
     # rides = orm.relationship("Ride", backref="athlete", lazy="dynamic", cascade="all, delete, delete-orphan")

--- a/freezing/web/templates/login.html
+++ b/freezing/web/templates/login.html
@@ -3,7 +3,7 @@
 <div class="jumbotron">
     <h1>Login using Strava</h1>
     <p class="lead">
-    	To acces additional information on the site, we ask that you authenticate using your Strava account.
+    	To view personalized competition information, please authenticate using your Strava account.
 	</p>
 	<p><a class="btn btn-lg" href="{{ authorize_url }}" role="button"><img src="/assets/img/ConnectWithStrava.png" border="0" width="262" height="43" /></a></p>
 </div>

--- a/freezing/web/templates/login_results.html
+++ b/freezing/web/templates/login_results.html
@@ -7,9 +7,13 @@
 
 {% if no_teams %}
 <p>
-	So you are a Strava athlete, we get that.  Unfortunately you are not registered with any of the configured Freezing
-	Saddles teams, so we can't authenticate you.
+	So you are a Strava athlete, we get that. Unfortunately, one of these two things is true:
+    <ol>
+        <li>you are not registered with any of the configured Freezing Saddles teams, or</li>
+        <li>you did not give Strava permission for us to "View your complete Strava profile". Without that, we can't see what clubs you belong to.</li>
+    </ul>
 </p>
+<p>If the latter is true, try to login again and grant us permission to "View your complete Strava profile".</p>
 {% else %}
 <p>
 	<strong>You are logged-in and have access to otherwise-private activity and athlete data.</strong>

--- a/freezing/web/views/general.py
+++ b/freezing/web/views/general.py
@@ -173,7 +173,7 @@ def join():
     private_url = c.authorization_url(client_id=config.STRAVA_CLIENT_ID,
                                       redirect_uri=url_for('.authorization', _external=True),
                                       approval_prompt='auto',
-                                      scope='view_private')
+                                      scope=['read_all','activity:read_all','profile:read_all'])
     return render_template('authorize.html',
                            public_authorize_url=public_url,
                            private_authorize_url=private_url,

--- a/freezing/web/views/general.py
+++ b/freezing/web/views/general.py
@@ -103,11 +103,14 @@ def index():
 @blueprint.route("/login")
 def login():
     c = Client()
-    url = c.authorization_url(client_id=config.STRAVA_CLIENT_ID,
-                              redirect_uri=url_for('.logged_in', _external=True),
-                              approval_prompt='auto')
+    url = c.authorization_url(
+        client_id=config.STRAVA_CLIENT_ID,
+        redirect_uri=url_for('.logged_in', _external=True),
+        approval_prompt='auto',
+        scope=['read_all', 'activity:read_all', 'profile:read_all'],
+    )
     return render_template('login.html',
-			   authorize_url=url,
+                           authorize_url=url,
                            competition_title=config.COMPETITION_TITLE)
 
 @blueprint.route("/logout")
@@ -139,7 +142,7 @@ def logged_in():
         # Use the now-authenticated client to get the current athlete
         strava_athlete = client.get_athlete()
 
-        athlete_model = data.update_athlete_auth(strava_athlete.id, token_dict)
+        athlete_model = data.update_athlete_auth(strava_athlete, token_dict)
         if not athlete_model:
             return render_template('login_error.html',
                                    error="ATHLETE_NOT_FOUND",
@@ -167,13 +170,18 @@ def logged_in():
 @blueprint.route("/authorize")
 def join():
     c = Client()
-    public_url = c.authorization_url(client_id=config.STRAVA_CLIENT_ID,
-                                     redirect_uri=url_for('.authorization', _external=True),
-                                     approval_prompt='auto')
-    private_url = c.authorization_url(client_id=config.STRAVA_CLIENT_ID,
-                                      redirect_uri=url_for('.authorization', _external=True),
-                                      approval_prompt='auto',
-                                      scope=['read_all','activity:read_all','profile:read_all'])
+    public_url = c.authorization_url(
+        client_id=config.STRAVA_CLIENT_ID,
+        redirect_uri=url_for('.authorization', _external=True),
+        approval_prompt='auto',
+        scope=['read', 'activity:read', 'profile:read_all'],
+    )
+    private_url = c.authorization_url(
+        client_id=config.STRAVA_CLIENT_ID,
+        redirect_uri=url_for('.authorization', external=True),
+        approval_prompt='auto',
+        scope=['read_all', 'activity:read_all', 'profile:read_all'],
+    )
     return render_template('authorize.html',
                            public_authorize_url=public_url,
                            private_authorize_url=private_url,

--- a/freezing/web/views/general.py
+++ b/freezing/web/views/general.py
@@ -133,13 +133,13 @@ def logged_in():
     else:
         code = request.args.get('code')
         client = Client()
-        access_token = client.exchange_code_for_token(client_id=config.STRAVA_CLIENT_ID,
-                                                      client_secret=config.STRAVA_CLIENT_SECRET,
-                                                      code=code)
+        token_dict = client.exchange_code_for_token(client_id=config.STRAVA_CLIENT_ID,
+                                                    client_secret=config.STRAVA_CLIENT_SECRET,
+                                                    code=code)
         # Use the now-authenticated client to get the current athlete
         strava_athlete = client.get_athlete()
 
-        athlete_model = meta.scoped_session().query(Athlete).get(strava_athlete.id)
+        athlete_model = data.update_athlete_auth(strava_athlete.id, token_dict)
         if not athlete_model:
             return render_template('login_error.html',
                                    error="ATHLETE_NOT_FOUND",
@@ -196,12 +196,12 @@ def authorization():
     else:
         code = request.args.get('code')
         client = Client()
-        access_token = client.exchange_code_for_token(client_id=config.STRAVA_CLIENT_ID,
-                                                      client_secret=config.STRAVA_CLIENT_SECRET,
-                                                      code=code)
+        token_dict = client.exchange_code_for_token(client_id=config.STRAVA_CLIENT_ID,
+                                                    client_secret=config.STRAVA_CLIENT_SECRET,
+                                                    code=code)
         # Use the now-authenticated client to get the current athlete
         strava_athlete = client.get_athlete()
-        athlete_model = data.register_athlete(strava_athlete, access_token)
+        athlete_model = data.register_athlete(strava_athlete, token_dict)
         multiple_teams = None
         no_teams = False
         team = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 stravalib>=0.8.0
 polyline==1.3.2
--e git+https://github.com/freezingsaddles/freezing-model@0.2.6#egg=freezing-model
+-e git+https://github.com/freezingsaddles/freezing-model@0.3.0#egg=freezing-model
 geojson==1.3.2
 PyMySQL==0.8.0
 arrow==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ colorlog==2.0.0
 python-instagram==1.3.2
 marshmallow==2.15.1
 gunicorn==19.7.1
-Flask==0.12.3
+Flask==0.12.4
 envparse==0.2.0
 -e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
 PyYAML==3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 stravalib>=0.8.0
 polyline==1.3.2
--e git+https://github.com/freezingsaddles/freezing-model@0.3.0#egg=freezing-model
+-e git+https://github.com/freezingsaddles/freezing-model@0.3.1#egg=freezing-model
 geojson==1.3.2
 PyMySQL==0.8.0
 arrow==0.12.1


### PR DESCRIPTION
Updates to authorization endpoints and the functions they call to deal with
storing both access tokens, refresh tokens, and the time they expire.

This requires freezing-model 0.3.0+ to get updated models that support the
athlete.refresh_token and athlete.expires_at models.

Update scopes to those currently supported by Strava