### PR TITLE
Fix double exceptions

### DIFF
--- a/freezing/web/views/general.py
+++ b/freezing/web/views/general.py
@@ -232,10 +232,10 @@ def authorization():
                     )
         except MultipleTeamsError as multx:
             multiple_teams = multx.teams
-            message = multx.str()
+            message = multx
         except NoTeamsError as noteamx:
             no_teams = True
-            message = noteamx.str()
+            message = noteamx
 
         return render_template(
             'authorization_success.html',


### PR DESCRIPTION
```
[2019-01-14 13:55:21 +0000] [9] [ERROR] Error handling request /authorization?state=&code=7f1f632befb6954108115c196fd803909fbf9d50&scope=read,activity:read_all,profile:read_all,read_all
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/freezing/web/views/general.py", line 231, in authorization
    athlete_model=athlete_model,
  File "/usr/local/lib/python3.6/dist-packages/freezing/web/data.py", line 206, in register_athlete_team
    raise MultipleTeamsError(matches)
freezing.web.exc.MultipleTeamsError: [<Club id=496122 name='Team 12 - The Freezing Dozen' resource_state=2>, <Club id=496919 name='Team never2cold' resource_state=2>]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.6/dist-packages/freezing/web/views/general.py", line 235, in authorization
    message = multx.str()
AttributeError: 'MultipleTeamsError' object has no attribute 'str'
[2019-01-14 14:16:16 +0000] [9] [ERROR] Error handling request /authorization?state=&code=018234cf590b4655561cc5d93b58d1d2aa859d25&scope=read,activity:read,profile:read_all
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/freezing/web/views/general.py", line 231, in authorization
    athlete_model=athlete_model,
  File "/usr/local/lib/python3.6/dist-packages/freezing/web/data.py", line 218, in register_athlete_team
    strava_athlete.clubs,
freezing.web.exc.NoTeamsError: Athlete 21492755 (Tom Milani): No teams matched ours. Teams defined: [<Club id=275028 name='The Institute For Defense Analyses' resource_state=2>]
```