### PR TITLE
Adds credits footer to each page. Closes #115

### DIFF
--- a/freezing/web/templates/base.html
+++ b/freezing/web/templates/base.html
@@ -215,6 +215,19 @@
         })
 </script>
 
-{% block foot %} {% endblock %}
+
+{% block foot %}
+{% endblock %}
+
+<div id="credits" class="container-fluid">
+  <div class="col-md-12">
+    <p>
+      Inspired by <a href="https://github.com/ronwalf/ba-winter-challenge">original scoreboard by ronwalf</a>.
+      BikeArlington Freezing Saddles software is open-source and <a href="https://github.com/freezingsaddles/">
+      available on Github</a>.
+    </p>
+  </div>
+</div>
+
 </body>
 </html>

--- a/freezing/web/templates/index.html
+++ b/freezing/web/templates/index.html
@@ -177,15 +177,6 @@ position: absolute; top:0; left: 0; width: 100%; height: 100%;
         </p>
 	</div>
 	</div>
-	<div class="row">
-		<div class="col-md-12">
-		<p>
-		    Inspired by <a href="https://github.com/ronwalf/ba-winter-challenge">original scoreboard by ronwalf</a>.
-		    BikeArlington Freezing Saddles software is open-source and <a href="https://github.com/hozn/bafs">available on
-		    Github</a>.
-		</p>
-	</div>
-	</div>
 	</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This adds credits and a link to the GitHub repository on each page by
adding a paragraph after the footer block. The credits on index.html
are removed.