### PR TITLE
Simplify Dockerfile - alpine base, run as freezing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,25 @@
 # BUILD
-# =====
-
-FROM ubuntu:xenial as buildstep
-
-COPY resources/docker/sources.list /etc/apt/sources.list
-RUN apt-get update
-
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:jonathonf/python-3.6
-RUN apt-get update
-
-RUN apt-get install -y python3.6 python3.6-dev libmysqlclient-dev curl build-essential git
-
-RUN mkdir -p /build/wheels
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
-
-RUN pip3 install --upgrade pip setuptools wheel
-
+FROM alpine as buildstep
+RUN apk update
+RUN apk add python3 py3-mysqlclient git
+RUN pip3 install --upgrade pip
 ADD requirements.txt /tmp/requirements.txt
-#RUN pip wheel -r /tmp/requirements.txt --no-binary MySQL-python --wheel-dir=/build/wheels
+RUN pip3 install -r /tmp/requirements.txt
+RUN mkdir -p /build/wheels
 RUN pip3 wheel -r /tmp/requirements.txt --wheel-dir=/build/wheels
 
+# DEPLOY
+FROM alpine as deploystep
+RUN apk update
+RUN apk add python3 py3-mysqlclient
+RUN pip3 install --upgrade pip
+RUN addgroup -S freezing && adduser -S -G freezing freezing
 ADD . /app
 WORKDIR /app
-
-RUN python3.6 setup.py bdist_wheel -d /build/wheels
-
-
-# DEPLOY
-# =====
-
-FROM ubuntu:xenial as deploystep
-
-COPY resources/docker/sources.list /etc/apt/sources.list
-
-RUN apt-get update \
-  && apt-get install -y software-properties-common curl \
-  && add-apt-repository -y ppa:jonathonf/python-3.6 \
-  && apt-get update \
-  && apt-get install -y python3.6 libmysqlclient-dev vim-tiny --no-install-recommends \
-  && apt-get clean \
-  && curl https://bootstrap.pypa.io/get-pip.py | python3.6 \
-  && pip3 install --upgrade pip setuptools wheel \
-  && rm -rf /var/lib/apt/lists/*
-
-ENV LEADERBOARDS_DIR=/data/leaderboards
-
+RUN python3 setup.py bdist_wheel -d /build/wheels
 RUN mkdir -p /data
 COPY leaderboards /data/leaderboards
-
-COPY --from=buildstep /build/wheels /tmp/wheels
-
-RUN pip3 install /tmp/wheels/*
-
+ENV LEADERBOARDS_DIR=/data/leaderboards
+USER freezing
 EXPOSE 8000
-
 ENTRYPOINT gunicorn --bind 0.0.0.0:8000 'freezing.web:app'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,15 @@
-# BUILD
-FROM alpine as buildstep
+FROM alpine
 RUN apk update
 RUN apk add python3 py3-mysqlclient git
 RUN pip3 install --upgrade pip
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
-RUN mkdir -p /build/wheels
-RUN pip3 wheel -r /tmp/requirements.txt --wheel-dir=/build/wheels
-
-# DEPLOY
-FROM alpine as deploystep
-RUN apk update
-RUN apk add python3 py3-mysqlclient
-RUN pip3 install --upgrade pip
+RUN apk del git
 RUN addgroup -S freezing && adduser -S -G freezing freezing
 ADD . /app
-WORKDIR /app
-RUN python3 setup.py bdist_wheel -d /build/wheels
 RUN mkdir -p /data
 COPY leaderboards /data/leaderboards
+WORKDIR /app
 ENV LEADERBOARDS_DIR=/data/leaderboards
 USER freezing
 EXPOSE 8000

--- a/resources/docker/sources.list
+++ b/resources/docker/sources.list
@@ -1,5 +1,0 @@
-deb http://archive.ubuntu.com/ubuntu/ xenial main universe
-deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe
-
-deb http://security.ubuntu.com/ubuntu xenial-security main
-deb http://security.ubuntu.com/ubuntu xenial-security universe


### PR DESCRIPTION
This works with Alpine linux just fine. The `Dockerfile` is much simpler this way.

These changes also make the app run as a non-root-user named `freezing` for better security.

This shrinks the image by almost 2/3:
```
$ docker images | grep freezing-web
local/freezing-web             latest              268e4449c3c1        41 minutes ago      121MB
freezingsaddles/freezing-web   latest              426eef8bfff0        28 hours ago        331MB
```