### PR TITLE
Tech/team weekly

### DIFF
--- a/freezing/web/templates/explore/indiv_elev_dist.html
+++ b/freezing/web/templates/explore/indiv_elev_dist.html
@@ -11,37 +11,35 @@
       
       function drawChart() {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/indiv_elev_dist",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-		
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.BubbleChart(document.getElementById('chart_div'));
-		/*	      
+	          dataType: "json"
+          }).done(function(jsonData) {
+
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
+
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.BubbleChart(document.getElementById('chart_div'));
+              /*
 	      var options = {'title':'Team Cumulative Points',
                        'width':1000,
                        'height':800};
           */
-          var options = {
-	          title: 'Correlation between distance, elevation, and average speed.',
-	          hAxis: {title: 'Distance'},
-	          vAxis: {title: 'Elevation'},
-	          height: 800,
-	          width: 1200,
-	          legend: {position: 'none'},
-	          bubble: {textStyle: {fontSize: 11}},
-	          chartArea :{left:200, top:50, width: 1000, height: 700},
-          };
+              var options = {
+                  title: 'Correlation between distance, elevation, and average speed.',
+                  hAxis: {title: 'Distance'},
+                  vAxis: {title: 'Elevation'},
+                  height: 800,
+                  width: 1200,
+                  legend: {position: 'none'},
+                  bubble: {textStyle: {fontSize: 11}},
+                  chartArea: {left: 200, top: 50, width: 1000, height: 700},
+              };
 
-        
-        
-	      chart.draw(data, options);
-	      
+
+              chart.draw(data, options);
+          });
 	  }
 	  
 	  </script>

--- a/freezing/web/templates/explore/riders_by_lowtemp.html
+++ b/freezing/web/templates/explore/riders_by_lowtemp.html
@@ -15,29 +15,29 @@
       
       function drawPointsChart() {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/riders_by_lowtemp",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-		
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.ComboChart(document.getElementById('chart'));
-	      
-	      var options = {title:'Riders by Avg Low Temp',
-                         width: 1000,
-                         height: 800,
-                         vAxis: {title: "Num Participating Riders / Avg Low Temps (F)"},
-          			     hAxis: {title: "Date"},
-          			     seriesType: "bars",
-          			     series: {1: {type: "line"}}
-          			     };
-                       
-	      chart.draw(data, options);
-	      
+	          dataType: "json"
+          }).done(function(jsonData) {
+
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
+
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.ComboChart(document.getElementById('chart'));
+
+              var options = {
+                  title: 'Riders by Avg Low Temp',
+                  width: 1000,
+                  height: 800,
+                  vAxis: {title: "Num Participating Riders / Avg Low Temps (F)"},
+                  hAxis: {title: "Date"},
+                  seriesType: "bars",
+                  series: {1: {type: "line"}}
+              };
+
+              chart.draw(data, options);
+          });
 	  }
 	  </script>
 {% endblock %}

--- a/freezing/web/templates/explore/team_cumul.html
+++ b/freezing/web/templates/explore/team_cumul.html
@@ -15,46 +15,48 @@
       
       function drawPointsChart() {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/team_cumul_points",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-		
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.LineChart(document.getElementById('chart_team_cumul_points'));
-	      
-	      var options = {'title':'Team Cumulative Points',
-                       'width':1000,
-                       'height':800};
-                       
-	      chart.draw(data, options);
-	      
+	          dataType: "json"
+          }).done(function(jsonData) {
+
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
+
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.LineChart(document.getElementById('chart_team_cumul_points'));
+
+              var options = {
+                  'title': 'Team Cumulative Points',
+                  'width': 1000,
+                  'height': 800
+              };
+
+              chart.draw(data, options);
+          });
 	  }
 	  
 	  function drawMileageChart() {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/team_cumul_mileage",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-		
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.LineChart(document.getElementById('chart_team_cumul_mileage'));
-	      
-	      var options = {'title':'Team Cumulative Mileage',
-                       'width':1000,
-                       'height':800};
-                       
-	      chart.draw(data, options);
-	      
+	          dataType: "json"
+          }).done(function(jsonData) {
+
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
+
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.LineChart(document.getElementById('chart_team_cumul_mileage'));
+
+              var options = {
+                  'title': 'Team Cumulative Mileage',
+                  'width': 1000,
+                  'height': 800
+              };
+
+              chart.draw(data, options);
+          });
 	  }
 	  
 	  </script>

--- a/freezing/web/templates/explore/team_weekly_points.html
+++ b/freezing/web/templates/explore/team_weekly_points.html
@@ -15,37 +15,38 @@
       
       function drawPointsChart() {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/team_weekly_points",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-/*		      
+	          dataType: "json"
+          }).done(function(jsonData) {
+
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
+              /*
         var data = google.visualization.arrayToDataTable([
           ['Week No.', 'Team 1', 'Team 2'],
           ['Week 9',  750.2168827056885,      992.3467163443565],
           ['Week 10',  502.17876356840134,      511.0094782114029],
         ]);
 */
-		  console.log(data);
-		  
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.ColumnChart(document.getElementById('chart_team_weekly_points'));
-	      
-	      var options = {'title':'Team Weekly Points',
-                       'width':1200,
-                       'height':800,
-                       'hAxis': {title: "Week No."},
-                       'vAxis': {title: "Points"},
-                       legend: {position: 'none'},
-                       chartArea :{left:200, top:50, width: 1000, height: 700}
-                       };
-            
-                     
-	      chart.draw(data, options);
+              console.log(data);
+
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.ColumnChart(document.getElementById('chart_team_weekly_points'));
+
+              var options = {
+                  'title': 'Team Weekly Points',
+                  'width': 1200,
+                  'height': 800,
+                  'hAxis': {title: "Week No."},
+                  'vAxis': {title: "Points"},
+                  legend: {position: 'none'},
+                  chartArea: {left: 200, top: 50, width: 1000, height: 700}
+              };
+
+
+              chart.draw(data, options);
+          });
 	      
 	  }
 	  	  

--- a/freezing/web/templates/leaderboard/indiv_various.html
+++ b/freezing/web/templates/leaderboard/indiv_various.html
@@ -59,7 +59,7 @@
   		<select name="api_method" id="api_method">
   			<option value="indiv_elev_gain" selected="selected">Elevation Gain</option>
   			<option value="indiv_moving_time">Time in the Saddle</option>
-  			<option value="indiv_number_sleaze_days">Number of Sleaze (11-12 point) Days</option>
+  			<option value="indiv_number_sleaze_days">Number of Sleaze (at least 1 mile, less than 2 mile) Days</option>
   			<option value="indiv_avg_speed">Average Speed</option>
   			<option value="indiv_segment/1081507">Hains Point Laps</option>
   			<option value="indiv_freezing">Rides (Miles) Below Freezing</option>

--- a/freezing/web/templates/leaderboard/indiv_various.html
+++ b/freezing/web/templates/leaderboard/indiv_various.html
@@ -59,7 +59,7 @@
   		<select name="api_method" id="api_method">
   			<option value="indiv_elev_gain" selected="selected">Elevation Gain</option>
   			<option value="indiv_moving_time">Time in the Saddle</option>
-  			<option value="indiv_number_sleaze_days">Number of Sleaze (at least 1 mile, less than 2 mile) Days</option>
+  			<option value="indiv_number_sleaze_days">Number of Sleaze (at least 1 mile, less than 2 miles) Days</option>
   			<option value="indiv_avg_speed">Average Speed</option>
   			<option value="indiv_segment/1081507">Hains Point Laps</option>
   			<option value="indiv_freezing">Rides (Miles) Below Freezing</option>

--- a/freezing/web/templates/leaderboard/indiv_various.html
+++ b/freezing/web/templates/leaderboard/indiv_various.html
@@ -21,13 +21,16 @@
 
 			  // Instantiate and draw our chart, passing in some options.
 			  var chart = new google.visualization.BarChart(document.getElementById('chart_indiv_leaderboard'));
+			  var rows = jsonData.rows.length;
 
 			  var options = {
 				  'title': "Individual " + label,
 				  'width': 800,
-				  'height': 4000,
+				  'height': 100 + rows * 24,
 				  'legend': {'position': 'none'},
-				  'chartArea': {'left': 200, 'top': 70, 'width': 550, 'height': 4000}
+				  'chartArea': {'left': 200, 'top': 70, 'width': 550, 'height': rows * 24},
+				  'hAxis': {'textStyle': {'fontSize': 16}},
+				  'vAxis': {'textStyle': {'fontSize': 16}},
 			  };
 
 			  chart.draw(data, options);

--- a/freezing/web/templates/leaderboard/indiv_various.html
+++ b/freezing/web/templates/leaderboard/indiv_various.html
@@ -11,26 +11,27 @@
 
 	  function drawIndivChart(api_method, label) {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/"+api_method,
-	          dataType:"json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-	
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.BarChart(document.getElementById('chart_indiv_leaderboard'));
-	      
-	      var options = {'title': "Individual " + label,
-                       'width':800,
-                       'height':4000,
-                       'legend': {'position': 'none'},
-                       'chartArea' :{'left':200,'top':70,'width': 550, 'height': 4000 }};
-                       
-	      chart.draw(data, options);
-	      
+	          dataType:"json"
+		  }).done(function(jsonData) {
+
+			  // Create our data table out of JSON data loaded from server.
+			  var data = new google.visualization.DataTable(jsonData);
+
+			  // Instantiate and draw our chart, passing in some options.
+			  var chart = new google.visualization.BarChart(document.getElementById('chart_indiv_leaderboard'));
+
+			  var options = {
+				  'title': "Individual " + label,
+				  'width': 800,
+				  'height': 4000,
+				  'legend': {'position': 'none'},
+				  'chartArea': {'left': 200, 'top': 70, 'width': 550, 'height': 4000}
+			  };
+
+			  chart.draw(data, options);
+		  });
 	  }
 	  
 

--- a/freezing/web/templates/leaderboard/team_various.html
+++ b/freezing/web/templates/leaderboard/team_various.html
@@ -59,7 +59,7 @@
   		<select name="api_method" id="api_method">
   			<option value="team_elev_gain" selected="selected">Elevation Gain</option>
   			<option value="team_moving_time">Time in the Saddle</option>
-  			<option value="team_number_sleaze_days">Number of Sleaze (1-2 mile) Days</option>
+  			<option value="team_number_sleaze_days">Number of Sleaze (at least 1 mile, less than 2 miles) Days</option>
   			<option value="team_avg_speed">Average Speed</option>
   			<option value="team_segment/1081507">Hains Point Laps</option>
   		</select>

--- a/freezing/web/templates/leaderboard/team_various.html
+++ b/freezing/web/templates/leaderboard/team_various.html
@@ -21,13 +21,16 @@
 
 			  // Instantiate and draw our chart, passing in some options.
 			  var chart = new google.visualization.BarChart(document.getElementById('chart_team_leaderboard'));
+			  var rows = jsonData.rows.length;
 
 			  var options = {
 				  'title': "Team " + label,
 				  'width': 1000,
-				  'height': 600,
+				  'height': 100 + rows * 24,
 				  'legend': {'position': 'none'},
-				  'chartArea': {'left': 300, 'top': 70, 'width': 550, 'height': 500}
+				  'chartArea': {'left': 300, 'top': 70, 'width': 550, 'height': rows * 24},
+				  'hAxis': {'textStyle': {'fontSize': 16}},
+				  'vAxis': {'textStyle': {'fontSize': 16}},
 			  };
 
 			  chart.draw(data, options);

--- a/freezing/web/templates/leaderboard/team_various.html
+++ b/freezing/web/templates/leaderboard/team_various.html
@@ -11,26 +11,27 @@
 
 	  function drawChart(api_method, label) {
 	      
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/"+api_method,
-	          dataType:"json",
-	          async: false // ... really?
-	          }).responseText;
-	          
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
-	
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.BarChart(document.getElementById('chart_team_leaderboard'));
-	      
-	      var options = {'title': "Team " + label,
-                       'width':1000,
-                       'height':600,
-                       'legend': {'position': 'none'},
-                       'chartArea' :{'left':300,'top':70,'width': 550,'height': 500}};
-                       
-	      chart.draw(data, options);
-	      
+	          dataType:"json"
+		  }).done(function(jsonData) {
+
+			  // Create our data table out of JSON data loaded from server.
+			  var data = new google.visualization.DataTable(jsonData);
+
+			  // Instantiate and draw our chart, passing in some options.
+			  var chart = new google.visualization.BarChart(document.getElementById('chart_team_leaderboard'));
+
+			  var options = {
+				  'title': "Team " + label,
+				  'width': 1000,
+				  'height': 600,
+				  'legend': {'position': 'none'},
+				  'chartArea': {'left': 300, 'top': 70, 'width': 550, 'height': 500}
+			  };
+
+			  chart.draw(data, options);
+		  });
 	  }
 	  
 

--- a/freezing/web/templates/user/rides.html
+++ b/freezing/web/templates/user/rides.html
@@ -19,56 +19,58 @@
 
       function drawDailyPointsChart() {
 
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/user_daily_points/{{ session.get('athlete_id') }}",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
+	          dataType: "json"
+          }).done(function(jsonData) {
 
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
 
-		  console.log(data);
+              console.log(data);
 
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.ColumnChart(document.getElementById('chart_user_daily_points'));
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.ColumnChart(document.getElementById('chart_user_daily_points'));
 
-	      var options = {'title':'Daily Points',
-                       'width':1000,
-                       'height':250,
-                       'hAxis': {title: "Day No."},
-                       'vAxis': {title: "Points"},
-                       legend: {position: 'none'},
-                       chartArea: {left:75, top:50}
-                       };
-	      chart.draw(data, options);
+              var options = {
+                  'title': 'Daily Points',
+                  'width': 1000,
+                  'height': 250,
+                  'hAxis': {title: "Day No."},
+                  'vAxis': {title: "Points"},
+                  legend: {position: 'none'},
+                  chartArea: {left: 75, top: 50}
+              };
+              chart.draw(data, options);
+          });
 	  }
 
 	  function drawWeeklyPointsChart() {
 
-	      var jsonData = $.ajax({
+	      $.ajax({
 	          url: "/chartdata/user_weekly_points/{{ session.get('athlete_id') }}",
-	          dataType: "json",
-	          async: false // ... really?
-	          }).responseText;
+	          dataType: "json"
+          }).done(function(jsonData) {
 
-	      // Create our data table out of JSON data loaded from server.
-	      var data = new google.visualization.DataTable(jsonData);
+              // Create our data table out of JSON data loaded from server.
+              var data = new google.visualization.DataTable(jsonData);
 
-		  console.log(data);
+              console.log(data);
 
-	      // Instantiate and draw our chart, passing in some options.
-	      var chart = new google.visualization.ColumnChart(document.getElementById('chart_user_weekly_points'));
+              // Instantiate and draw our chart, passing in some options.
+              var chart = new google.visualization.ColumnChart(document.getElementById('chart_user_weekly_points'));
 
-	      var options = {'title':'Weekly Points',
-                       'width': 1000,
-                       'height':250,
-                       'hAxis': {title: "Day No."},
-                       'vAxis': {title: "Points"},
-                       legend: {position: 'none'},
-                       chartArea: {left:75, top:50}
-                       };
-	      chart.draw(data, options);
+              var options = {
+                  'title': 'Weekly Points',
+                  'width': 1000,
+                  'height': 250,
+                  'hAxis': {title: "Day No."},
+                  'vAxis': {title: "Points"},
+                  legend: {position: 'none'},
+                  chartArea: {left: 75, top: 50}
+              };
+              chart.draw(data, options);
+          });
 	  }
 
 	  </script>

--- a/freezing/web/views/chartdata.py
+++ b/freezing/web/views/chartdata.py
@@ -558,8 +558,17 @@ def team_weekly_points():
     """
 
     q = text("""
-             select WS.team_id, WS.team_name, WS.week_num, (sum(WS.team_distance) + sum(WS.days)*10) as total_score
-             from weekly_stats WS group by WS.team_id, WS.team_name, WS.week_num order by WS.team_id, WS.week_num
+             select
+               DS.team_id as team_id,
+               T.name as team_name,
+               sum(DS.points) as total_score,
+               week(DS.ride_date) as week_num
+             from
+               daily_scores DS inner join
+               teams T on T.id = DS.team_id
+             group by
+               team_id,
+               week_num
              ;
              """)
     cols = [{'id': 'week', 'label': 'Week No.', 'type': 'string'}]
@@ -570,7 +579,7 @@ def team_weekly_points():
     for r in res:
         d[r['week_num']].append((r['team_id'], r['team_name'], r['total_score']))
     for week, datalist in d.items():
-        cells = [{'v': 'Week {0}'.format(week), 'f': 'Week {0}'.format(week)}]
+        cells = [{'v': 'Week {0}'.format(week + 1), 'f': 'Week {0}'.format(week + 1)}]
         for team_id, team_name, total_score in datalist:
             cells.append({'v': total_score, 'f': '{0:.2f}'.format(total_score)})
         rows.append({'c': cells})


### PR DESCRIPTION
Cleanup to remove synchronous calls and adapt a few more charts to the row count. Alter team weekly calculation to just pull from daily scores. Closes #135.