### PR TITLE
end of ride days

### DIFF
--- a/freezing/web/templates/people/ridedays.html
+++ b/freezing/web/templates/people/ridedays.html
@@ -9,7 +9,7 @@
 	<tr><th>Rider</th><th>Days</th><th>Miles</th></tr>
 {% for a, b, c, d, e in ride_days %}
 	{% if c >= num_days %}<tr class="success">
-	{% elif c == (num_days - 1) and not e %}<tr class="warning">
+	{% elif c == (num_days - 1) and not e and not all_done %}<tr class="warning">
 	{% elif c < num_days %}<tr class="danger">
 	{% endif %}
 <td><a href="/people/{{a}}">{{b}}</a></td><td>{{c}}</td><td>{{d | round(1)}}</td></tr>


### PR DESCRIPTION
Stop the ride-days clock at the end of the competition. Adjust ordering of one-day-short riders to put contenders above non-contenders. Resolves #118.