### PR TITLE
Fix Yaml loader and get working docker-compose localdev environment working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
 
-  db:
+  freezing-db:
     image: mysql:5.6
     container_name: freezing-db
     ports:
@@ -21,31 +21,34 @@ services:
       MYSQL_USER: ${MYSQL_USER:-freezing}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-zeer0}
 
-  web:
+  freezing-web:
     build: .
-    container_name: web
+    container_name: freezing-web
     command: bafs-server
     ports:
       - "5000:8000"
     volumes:
-      - ./data:/data
+      - ./data/cache:/data/cache
+      - ./leaderboards:/data/leaderboards
+      - ./data/sessions:/data/sessions
       - ./resources/docker/settings.cfg:/config/settings.cfg
     links:
-      - db:db.container
+      - freezing-db:freezing-db.container
     environment:
       VIRTUAL_HOST: ${FREEZING_WEB_FQDN}
       LETSENCRYPT_HOST: ${FREEZING_WEB_FQDN}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
       SECRET_KEY: ${SECRET_KEY}
       DEBUG: ${DEBUG}
-      SQLALCHEMY_URL: ${SQLALCHEMY_URL:-mysql+pymysql://freezing:zeer0@db.container/freezing?charset=utf8mb4&binary_prefix=true}
+      SQLALCHEMY_URL: ${SQLALCHEMY_URL:-mysql+pymysql://freezing:zeer0@freezing-db.container/freezing?charset=utf8mb4&binary_prefix=true}
       BEANSTALKD_HOST: beanstalkd.container
       BEANSTALKD_PORT: 11300
       STRAVA_CLIENT_ID: ${STRAVA_CLIENT_ID}
       STRAVA_CLIENT_SECRET: ${STRAVA_CLIENT_SECRET}
       TEAMS: ${TEAMS}
       OBSERVER_TEAMS: ${OBSERVER_TEAMS}
+      MAIN_TEAM: ${MAIN_TEAM}
       START_DATE: ${START_DATE}
       END_DATE: ${END_DATE}
       TIMEZONE: ${TIMEZONE:-America/New_York}
-      COMPETITION_TITLE: ${COMPETITION_TITLE:-Freezing Saddles}
+      COMPETITION_TITLE: ${COMPETITION_TITLE:-Freezing Saddles Local Dev}

--- a/freezing/web/utils/genericboard.py
+++ b/freezing/web/utils/genericboard.py
@@ -113,7 +113,7 @@ def load_board(leaderboard) -> GenericBoard:
         raise ObjectNotFound("Could not find yaml board definition {}".format(path))
 
     with open(path, "rt", encoding="utf-8") as fp:
-        doc = yaml.load(fp)
+        doc = yaml.load(fp, loader=FullLoader)
 
     schema = GenericBoardSchema()
     board: GenericBoard = schema.load(doc)

--- a/freezing/web/utils/genericboard.py
+++ b/freezing/web/utils/genericboard.py
@@ -113,7 +113,7 @@ def load_board(leaderboard) -> GenericBoard:
         raise ObjectNotFound("Could not find yaml board definition {}".format(path))
 
     with open(path, "rt", encoding="utf-8") as fp:
-        doc = yaml.load(fp, loader=FullLoader)
+        doc = yaml.load(fp, Loader=yaml.FullLoader)
 
     schema = GenericBoardSchema()
     board: GenericBoard = schema.load(doc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/freezingsaddles/freezing-model@0.5.12#egg=freezing-model
+-e git+https://github.com/freezingsaddles/freezing-model@0.5.15#egg=freezing-model
 -e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
 Flask==1.1.1
 PyMySQL==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ __authors__ = ['"Hans Lellelid" <hans@xmpl.org>',
 
 __copyright__ = "Copyright 2015 Hans Lellelid"
 
-version = '1.1.12'
+version = '1.1.13'
 
 long_description="""
 The freezing saddles cycling competition website/scoreboard.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ __authors__ = ['"Hans Lellelid" <hans@xmpl.org>',
 
 __copyright__ = "Copyright 2015 Hans Lellelid"
 
-version = '1.1.11'
+version = '1.1.12'
 
 long_description="""
 The freezing saddles cycling competition website/scoreboard.


### PR DESCRIPTION
I tested this locally on a Windows system running Docker Desktop 3.0, using the docker-compose.yml changes here, plus a SQL dump file  freezing-2020-11-19.sql and an .env file derived from the production system from 2020. This fixes the regressions that made it into master, and reconciles the changes that had to be made with freezing-model too.

The docker image I built from this locally has been pushed to Docker Hub and deployed to production.