### PR TITLE
Do not clean out athletes for 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ shell$ git clone https://github.com/freezingsaddles/freezing-web.git
   * Revise any comments to reflect the new year
 * Delete all the data in the following MySQL tables: (see [freezing/sql/year-start.sql](https://github.com/freezingsaddles/freezing-web/blob/master/freezing/sql/year-start.sql))
   * teams
-  * athletes
   * rides
   * ride_geo
   * ride_weather

--- a/freezing/sql/year-start.sql
+++ b/freezing/sql/year-start.sql
@@ -10,8 +10,9 @@ select count(*) from ride_weather as ride_weather_count;
 /* Trying to truncate here was timing out, weirdly. That should be super fast, but it wasn't. Delete instead. */
 select 'cleaning out rides';
 delete from rides;
-select 'cleaning out athletes';
-delete from athletes;
+/* In past years we also cleaned out the athletes table, but in 2024 we announced
+   the registration to be live before this happened. So let's keep the athletes,
+   that way people won't absolutely have to register again. */
 select 'cleaning out teams';
 delete from teams;
 select 'cleaning out ride_geo';


### PR DESCRIPTION
We announced registration before we had cleaned out the athletes.

So let's avoid clearing the athletes table.

## Benefits
* people may not have to register again on the site using Strava

## Drawbacks 
* The database will swell with the ranks of folks who had registered
  last year but are not playing this year and their rides
* These users will ultimately be shown in the Frends of BAFS leaderboard
  for 2024 (and beyond if we keep not resetting this)
