### PR TITLE
Pointless fixes

### DIFF
--- a/freezing/web/templates/base.html
+++ b/freezing/web/templates/base.html
@@ -122,7 +122,7 @@
                         </a>
                         <ul class="dropdown-menu">
                             <!-- li><a href="/pointless/hashtag/biathlon">Biathlon</a></li -->
-                            <li><a href="https://www.bikearlingtonforum.com/forums/topic/bicycle-bingo-sign-up-now/">Bicycle Bingo</a></li>
+                            <li><a href="/pointless/hashtag/bingo">Bicycle Bingo</a></li>
                             <li><a href="https://www.bikearlingtonforum.com/forums/topic/return-of-calvinball/">Calvinball</a></li>
                             <li><a href="/pointless/billygoat-indiv">Climbing per Mile (Indiv)</a></li>
                             <li><a href="/pointless/billygoat-team">Climbing per Mile (Team)</a></li>

--- a/leaderboards/hashtag.yml
+++ b/leaderboards/hashtag.yml
@@ -42,6 +42,14 @@ tags:
     sponsor: smb9600
     rank_by_rides: True
 
+  - tag: bingo
+    name: Bicycle Bingo
+    description: |
+      Ride your bike and play Bingo!
+    url: https://www.bikearlingtonforum.com/forums/topic/bicycle-bingo-sign-up-now/
+    sponsor: cvcalhoun
+    rank_by_rides: True
+
   - tag: Deflated
     name: Don’t be deflated this prize is for you!
     description: |
@@ -169,7 +177,7 @@ tags:
       Riding singlespeed fell out of fashion years ago, but I still enjoy it. Does anyone else? Let's find out with a singlespeed pointless prize. See the linked forum post for complete rules and details.
     sponsor: jlamb
     url: https://www.bikearlingtonforum.com/forums/topic/pointless-prize-singlespeed-2/
-    rank_by_rides: True
+    rank_by_rides: False
 
   - tag: scavhunt
     name: Photo Scavenger Hunt

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ __authors__ = [
 
 __copyright__ = "Copyright 2015 Hans Lellelid"
 
-version = "1.2.0"
+version = "1.2.1"
 
 long_description = """
 The freezing saddles cycling competition website/scoreboard.


### PR DESCRIPTION
* Bicycle Bingo leaderboard
* For singlespeed this year, the number of rides doesn't matter. It's simply most miles wins. Delete the column that's tracking number of rides.