### PR TITLE
Fix Flask startup error from lack of instance_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .venv*
 /*.iml
 /build
-/data/cache/*
+/data/*
 /dist
 /env
 /freezing/web/version.py

--- a/freezing/web/__init__.py
+++ b/freezing/web/__init__.py
@@ -4,7 +4,7 @@ from freezing.model import init_model, meta
 from .config import config
 
 # Thanks https://stackoverflow.com/a/17073583
-app = Flask(__name__, static_folder="static", static_url_path="/")
+app = Flask(__name__, static_folder="static", static_url_path="/", instance_path=config.INSTANCE_PATH)
 app.config.from_object(config)
 
 init_model(config.SQLALCHEMY_URL)

--- a/freezing/web/__init__.py
+++ b/freezing/web/__init__.py
@@ -4,7 +4,12 @@ from freezing.model import init_model, meta
 from .config import config
 
 # Thanks https://stackoverflow.com/a/17073583
-app = Flask(__name__, static_folder="static", static_url_path="/", instance_path=config.INSTANCE_PATH)
+app = Flask(
+    __name__,
+    static_folder="static",
+    static_url_path="/",
+    instance_path=config.INSTANCE_PATH,
+)
 app.config.from_object(config)
 
 init_model(config.SQLALCHEMY_URL)

--- a/freezing/web/config.py
+++ b/freezing/web/config.py
@@ -20,50 +20,49 @@ _basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 class Config:
-    DEBUG: bool = env("DEBUG", cast=bool, default=False)
-    SECRET_KEY = env("SECRET_KEY")
+    """
+    Configuration for the application. These can be overridden by setting the appropriate environment variables.
 
-    SQLALCHEMY_URL = env("SQLALCHEMY_URL")
+    Refactored with the help of GitHub Copilot.
+    """
     BEANSTALKD_HOST = env("BEANSTALKD_HOST", default="localhost")
     BEANSTALKD_PORT = env("BEANSTALKD_PORT", cast=int, default=11300)
-
-    STRAVA_CLIENT_ID = env("STRAVA_CLIENT_ID")
-    STRAVA_CLIENT_SECRET = env("STRAVA_CLIENT_SECRET")
-
-    COMPETITION_TITLE = env("COMPETITION_TITLE", default="Freezing Saddles")
     COMPETITION_TEAMS: List[int] = env("TEAMS", cast=list, subcast=int, default=[])
-    OBSERVER_TEAMS: List[int] = env(
-        "OBSERVER_TEAMS", cast=list, subcast=int, default=[]
-    )
-    MAIN_TEAM: int = env("MAIN_TEAM", cast=int)
-
-    START_DATE: datetime = env(
-        "START_DATE", postprocessor=lambda val: arrow.get(val).datetime
-    )
+    COMPETITION_TITLE = env("COMPETITION_TITLE", default="Freezing Saddles")
+    DEBUG: bool = env("DEBUG", cast=bool, default=False)
     END_DATE: datetime = env(
         "END_DATE", postprocessor=lambda val: arrow.get(val).datetime
     )
+    # Environment (localdev, production, etc.)
+    ENVIRONMENT = env("ENVIRONMENT", default="localdev")
+    FORUM_SITE: str = env(
+        "FORUM_SITE",
+        "https://www.bikearlingtonforum.com/forums/forum/freezing-saddles-winter-riding-competition/",
+    )
+    INSTANCE_PATH = env("INSTANCE_PATH", default=os.path.join(_basedir, "data/instance"))
+    # Directory to store leaderboard data
+    LEADERBOARDS_DIR = env(
+        "LEADERBOARDS_DIR", default=os.path.join(_basedir, "leaderboards")
+    )
+    MAIN_TEAM: int = env("MAIN_TEAM", cast=int)
+    OBSERVER_TEAMS: List[int] = env(
+        "OBSERVER_TEAMS", cast=list, subcast=int, default=[]
+    )
+    REGISTRATION_SITE: str = env("REGISTRATION_SITE", "https://freezingsaddles.info/")
+    SECRET_KEY = env("SECRET_KEY")
+    SQLALCHEMY_URL = env("SQLALCHEMY_URL")
+    START_DATE: datetime = env(
+        "START_DATE", postprocessor=lambda val: arrow.get(val).datetime
+    )
+    STRAVA_CLIENT_ID = env("STRAVA_CLIENT_ID")
+    STRAVA_CLIENT_SECRET = env("STRAVA_CLIENT_SECRET")
     TIMEZONE: tzinfo = env(
         "TIMEZONE",
         default="America/New_York",
         postprocessor=lambda val: pytz.timezone(val),
     )
-
-    LEADERBOARDS_DIR = env(
-        "LEADERBOARDS_DIR", default=os.path.join(_basedir, "leaderboards")
-    )
-
-    FORUM_SITE: str = env(
-        "FORUM_SITE",
-        "https://www.bikearlingtonforum.com/forums/forum/freezing-saddles-winter-riding-competition/",
-    )
-    REGISTRATION_SITE: str = env("REGISTRATION_SITE", "https://freezingsaddles.info/")
-
     VERSION_NUM = version("freezing-web")
-
     VERSION_STRING = f"{VERSION_NUM}+{branch}.{commit}.{build_date}"
-
-    ENVIRONMENT = env("ENVIRONMENT", default="localdev")
 
 
 config = Config()

--- a/freezing/web/config.py
+++ b/freezing/web/config.py
@@ -25,6 +25,7 @@ class Config:
 
     Refactored with the help of GitHub Copilot.
     """
+
     BEANSTALKD_HOST = env("BEANSTALKD_HOST", default="localhost")
     BEANSTALKD_PORT = env("BEANSTALKD_PORT", cast=int, default=11300)
     COMPETITION_TEAMS: List[int] = env("TEAMS", cast=list, subcast=int, default=[])
@@ -39,7 +40,9 @@ class Config:
         "FORUM_SITE",
         "https://www.bikearlingtonforum.com/forums/forum/freezing-saddles-winter-riding-competition/",
     )
-    INSTANCE_PATH = env("INSTANCE_PATH", default=os.path.join(_basedir, "data/instance"))
+    INSTANCE_PATH = env(
+        "INSTANCE_PATH", default=os.path.join(_basedir, "data/instance")
+    )
     # Directory to store leaderboard data
     LEADERBOARDS_DIR = env(
         "LEADERBOARDS_DIR", default=os.path.join(_basedir, "leaderboards")


### PR DESCRIPTION
This was a weird one, it snuck in after we did some Flask upgrades at
some point.

```
$ APP_SETTINGS=development.cfg freezing-server
Traceback (most recent call last):
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/.venv/bin/freezing-server", line 5, in <module>
    from freezing.web.runserver import main
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/freezing/web/__init__.py", line 8, in <module>
    app = Flask(__name__, static_folder="static", static_url_path="/")
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/.venv/lib/python3.10/site-packages/flask/app.py", line 239, in __init__
    super().__init__(
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/.venv/lib/python3.10/site-packages/flask/sansio/app.py", line 304, in __init__
    instance_path = self.auto_find_instance_path()
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/.venv/lib/python3.10/site-packages/flask/sansio/app.py", line 518, in auto_find_instance_path
    prefix, package_path = find_package(self.import_name)
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/.venv/lib/python3.10/site-packages/flask/sansio/scaffold.py", line 767, in find_package
    package_path = _find_package_path(import_name)
  File "/Users/rbulling/Documents/src/freezingsaddles/freezing-web/.venv/lib/python3.10/site-packages/flask/sansio/scaffold.py", line 736, in _find_package_path
    search_location = next(
StopIteration
```
