### PR TITLE
Consider polylines instead of heatmap

### DIFF
--- a/freezing/web/templates/index.html
+++ b/freezing/web/templates/index.html
@@ -245,11 +245,35 @@ $(() => {
 		maxZoom: 20,
 	}).addTo(map);
 
-	fetch('/api/all/heatmap.json').then(r => r.json()).then(data => {
-		var points = data.points.map(([lon, lat]) => [lat, lon, 3]);
-        var heatMap = L.heatLayer(points, { radius: 3, blur: 2, maxZoom: 13});
-        map.addLayer(heatMap);
+	// https://mokole.com/palette.html - 25 / 20% / 80% / 5000
+	// const colors = [
+	// 	'#c0c0c0', '#2f4f4f', '#556b2f', '#800000', '#483d8b',
+	// 	'#3cb371', '#000080', '#9acd32', '#8b008b', '#ff0000',
+	// 	'#00ced1', '#ffa500', '#ffff00', '#7fff00', '#8a2be2',
+	// 	'#00ff7f', '#00bfff', '#0000ff', '#ff7f50', '#ff00ff',
+	// 	'#1e90ff', '#db7093', '#f0e68c', '#ff1493', '#ee82ee',
+	// ];
+
+	// https://observablehq.com/@shan/oklab-color-wheel - .65 / 26 / 2 / 0 / .29
+	const colors = [
+		'rgb(255, 0, 0)', 'rgb(255, 49, 0)', 'rgb(246, 83, 0)', 'rgb(224, 109, 0)', 'rgb(195, 132, 0)',
+		'rgb(157, 151, 0)', 'rgb(106, 166, 0)', 'rgb(0, 178, 0)', 'rgb(0, 186, 3)', 'rgb(0, 191, 99)',
+		'rgb(0, 191, 150)', 'rgb(0, 188, 194)', 'rgb(0, 180, 232)', 'rgb(0, 169, 255)', 'rgb(0, 154, 255)',
+		'rgb(0, 137, 255)', 'rgb(33, 119, 255)', 'rgb(112, 101, 255)', 'rgb(153, 83, 255)', 'rgb(185, 65, 255)',
+		'rgb(212, 44, 252)', 'rgb(234, 10, 218)', 'rgb(252, 0, 179)', 'rgb(255, 0, 136)', 'rgb(255, 0, 87)',
+	];
+
+	fetch('/api/all/trackmap.json').then(r => r.json()).then(data => {
+        // var points = data.tracks.flatMap(({track}) => track.map(([lon, lat]) => [lon, lat, 20]));
+        // var heatMap = L.heatLayer(points, { radius: 1, blur: 1, maxZoom: 13});
+        // map.addLayer(heatMap);
+        data.tracks.forEach(({ team, track}, index) => {
+            const color = colors[team % colors.length];
+            const opacity = .2 + .4 * (index + 1) / data.tracks.length;
+            var polyline = L.polyline([track], { color, opacity, weight: 2 }).addTo(map);
+        });
 	});
 });
 </script>
 {% endblock %}
+


### PR DESCRIPTION
I find the current heatmap to be too blurred. Making it less blurred, it becomes too spotty because of the sampling frequency along the paths. Polylines are much cleaner (here, colour-coded by team), but don't as clearly highlight activity. Upsampling the spotty paths results in too much geometry for the heatmap to handle performantly.

Current heatmap:

<img width="646" alt="Screenshot 2024-12-09 at 3 19 10 PM" src="https://github.com/user-attachments/assets/bb541f3c-a976-404e-af6c-b2fb10bf027d">

Less-blurred heatmap:

<img width="645" alt="Screenshot 2024-12-09 at 3 17 02 PM" src="https://github.com/user-attachments/assets/14f8495a-a48e-4cd5-8883-ec955e6a80b1">

Polylines instead:

<img width="646" alt="Screenshot 2024-12-09 at 3 16 46 PM" src="https://github.com/user-attachments/assets/f611fa9d-ab46-41ed-ad7b-ae80fae9202e">
