### PR TITLE
Test stravalib 2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ marshmallow-enum @ https://github.com/lyft/marshmallow_enum/archive/support-for-
 polyline==2.0.2
 python-instagram==1.3.2
 pytz==2024.2
-stravalib==1.2.0
+stravalib==2.1


### PR DESCRIPTION
Test Stravalib update on site, live

This just takes #284 and tests it with a PR that runs the full actions. Then we can test that version on the site.

Bumps [stravalib](https://github.com/stravalib/stravalib) from 1.2.0 to 2.1.
- [Release notes](https://github.com/stravalib/stravalib/releases)
- [Changelog](https://github.com/stravalib/stravalib/blob/main/changelog.md)
- [Commits](https://github.com/stravalib/stravalib/compare/v1.2.0...v2.1)

---
updated-dependencies:
- dependency-name: stravalib
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
