### PR TITLE
Add CaBi hashtag leaderboard entry

### DIFF
--- a/freezing/web/templates/base.html
+++ b/freezing/web/templates/base.html
@@ -207,7 +207,7 @@
                                     <a class="dropdown-item" href="/pointless/hashtag/bingo">Bicycle Bingo</a>
                                 </li>
                                 <li>
-                                    <a class="dropdown-item" href="/pointless/hashtag/cabi">CaBi</a>
+                                    <a class="dropdown-item" href="/pointless/hashtag/cabi">Capital Bikeshare</a>
                                 </li>
                                 <li>
                                     <a class="dropdown-item" href="/pointless/hashtag/civilwarforts">Civil War Forts</a>

--- a/freezing/web/templates/base.html
+++ b/freezing/web/templates/base.html
@@ -207,6 +207,9 @@
                                     <a class="dropdown-item" href="/pointless/hashtag/bingo">Bicycle Bingo</a>
                                 </li>
                                 <li>
+                                    <a class="dropdown-item" href="/pointless/hashtag/cabi">CaBi</a>
+                                </li>
+                                <li>
                                     <a class="dropdown-item" href="/pointless/hashtag/civilwarforts">Civil War Forts</a>
                                 </li>
                                 <li>

--- a/leaderboards/hashtag.yml
+++ b/leaderboards/hashtag.yml
@@ -41,6 +41,14 @@ tags:
     sponsor: cvcalhoun
     rank_by_rides: True
 
+  - tag: cabi
+    name: Capital Bikeshare (CaBi) Rides
+    description: |
+      Tag your rides on CaBi with <code>#cabi</code> (eBike or red bike!) and whoever does the most miles will get a prize. The prize is likely to either be a CaBi embroidery or whatever I have in my bag at the final happy hour (up to and including trivial cash amounts or random stickers). Get riding!
+    url: https://www.bikearlingtonforum.com/forums/topic/pointless-prize-cabi/
+    sponsor: veleau_monica
+    rank_by_rides: True
+
   - tag: civilwarforts
     name: Civil War Forts
     description: |

--- a/leaderboards/hashtag.yml
+++ b/leaderboards/hashtag.yml
@@ -42,9 +42,9 @@ tags:
     rank_by_rides: True
 
   - tag: cabi
-    name: Capital Bikeshare (CaBi) Rides
+    name: Capital Bikeshare Rides
     description: |
-      Tag your rides on CaBi with <code>#cabi</code> (eBike or red bike!) and whoever does the most miles will get a prize. The prize is likely to either be a CaBi embroidery or whatever I have in my bag at the final happy hour (up to and including trivial cash amounts or random stickers). Get riding!
+      Tag your rides on Capital Bikeshare (CaBi) with <code>#cabi</code> (eBike or red bike!) and whoever does the most miles will get a prize. The prize is likely to either be a CaBi embroidery or whatever I have in my bag at the final happy hour (up to and including trivial cash amounts or random stickers). Get riding!
     url: https://www.bikearlingtonforum.com/forums/topic/pointless-prize-cabi/
     sponsor: veleau_monica
     rank_by_rides: True


### PR DESCRIPTION
closes #386 

I also made a few decisions re: copy (calling the prize "Capital Bikeshsare" and using "CaBi" as the preferred contraction) and added the hashtag to the "Active Pointless Prizes" dropdown. Unsure if this was part of the request.