### PR TITLE
Rank by miles for #cabi leaderboard

### DIFF
--- a/leaderboards/hashtag.yml
+++ b/leaderboards/hashtag.yml
@@ -47,7 +47,7 @@ tags:
       Tag your rides on Capital Bikeshare (CaBi) with <code>#cabi</code> (eBike or red bike!) and whoever does the most miles will get a prize. The prize is likely to either be a CaBi embroidery or whatever I have in my bag at the final happy hour (up to and including trivial cash amounts or random stickers). Get riding!
     url: https://www.bikearlingtonforum.com/forums/topic/pointless-prize-cabi/
     sponsor: veleau_monica
-    rank_by_rides: True
+    rank_by_rides: False
 
   - tag: civilwarforts
     name: Civil War Forts


### PR DESCRIPTION
As @merlinorg  notes this leaderboard should be ranked by mileage, not rides. Tested locally:


<img width="1572" alt="image" src="https://github.com/user-attachments/assets/3dd465c2-bc6b-4bd7-b1ea-90a4a4d3f5a4" />


## References:

* #386 
* #396 