### PR TITLE
Persist session cookie for a month

### DIFF
--- a/freezing/web/utils/auth.py
+++ b/freezing/web/utils/auth.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import Forbidden
 
 
 def login_athlete(strava_athlete):
+    session.permanent = True
     session["athlete_id"] = strava_athlete.id
     session["athlete_avatar"] = strava_athlete.profile_medium
     session["athlete_fname"] = strava_athlete.firstname


### PR DESCRIPTION
Our current session cookie lasts until the browser is closed. On mobile (or at least Android) devices this means not very long at all. Switch to a 1-month cookie so you remain logged in long enough for it to be useful.