### PR TITLE
Move responsibility for transaction commit up closer to where it belongs

### DIFF
--- a/freezing/web/config.py
+++ b/freezing/web/config.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime, tzinfo
+from datetime import datetime, timedelta, tzinfo
 from importlib.metadata import version
 from typing import List
 
@@ -77,6 +77,8 @@ class Config:
         if ENVIRONMENT == "localdev"
         else 84600  # let the browser cache static files for 24 hours
     )
+    # From registration start (Thanksgiving) until shortly after the competition ends.
+    PERMANENT_SESSION_LIFETIME: timedelta = timedelta(days=128)
 
 
 config = Config()

--- a/freezing/web/data.py
+++ b/freezing/web/data.py
@@ -51,8 +51,6 @@ def register_athlete(strava_athlete, token_dict):
     athlete.refresh_token = token_dict["refresh_token"]
     athlete.expires_at = token_dict["expires_at"]
     meta.scoped_session().add(athlete)
-    # We really shouldn't be committing here, since we want to disambiguate names after registering
-    meta.scoped_session().commit()
 
     return athlete
 
@@ -82,49 +80,46 @@ def register_athlete_team(strava_athlete, athlete_model):
     # Figure out how to DRY (Don't Repeat Yourself) for this code.
 
     all_teams = config.COMPETITION_TEAMS
-    try:
-        if strava_athlete.clubs is None:
-            raise NoTeamsError(
-                "Athlete {0} ({1} {2}): No clubs returned- {3}. {4}.".format(
-                    strava_athlete.id,
-                    strava_athlete.firstname,
-                    strava_athlete.lastname,
-                    "Full Profile Access required",
-                    "Please re-authorize",
-                )
+    if strava_athlete.clubs is None:
+        raise NoTeamsError(
+            "Athlete {0} ({1} {2}): No clubs returned- {3}. {4}.".format(
+                strava_athlete.id,
+                strava_athlete.firstname,
+                strava_athlete.lastname,
+                "Full Profile Access required",
+                "Please re-authorize",
             )
-        matches = [c for c in strava_athlete.clubs if c.id in all_teams]
-        athlete_model.team = None
-        if len(matches) > 1:
-            # you can be on multiple teams
-            # as long as only one is an official team
-            matches = [c for c in matches if c.id not in config.OBSERVER_TEAMS]
-        if len(matches) > 1:
-            raise MultipleTeamsError(matches)
-        if len(matches) == 0:
-            # Fall back to main team if it is the only team they are in
-            matches = [c for c in strava_athlete.clubs if c.id == config.MAIN_TEAM]
-        if len(matches) == 0:
-            raise NoTeamsError(
-                "Athlete {0} ({1} {2}): {3} {4}".format(
-                    strava_athlete.id,
-                    strava_athlete.firstname,
-                    strava_athlete.lastname,
-                    "No teams matched ours. Teams defined:",
-                    strava_athlete.clubs,
-                )
+        )
+    matches = [c for c in strava_athlete.clubs if c.id in all_teams]
+    athlete_model.team = None
+    if len(matches) > 1:
+        # you can be on multiple teams
+        # as long as only one is an official team
+        matches = [c for c in matches if c.id not in config.OBSERVER_TEAMS]
+    if len(matches) > 1:
+        raise MultipleTeamsError(matches)
+    if len(matches) == 0:
+        # Fall back to main team if it is the only team they are in
+        matches = [c for c in strava_athlete.clubs if c.id == config.MAIN_TEAM]
+    if len(matches) == 0:
+        raise NoTeamsError(
+            "Athlete {0} ({1} {2}): {3} {4}".format(
+                strava_athlete.id,
+                strava_athlete.firstname,
+                strava_athlete.lastname,
+                "No teams matched ours. Teams defined:",
+                strava_athlete.clubs,
             )
-        else:
-            club = matches[0]
-            # create the team row if it does not exist
-            team = meta.scoped_session().query(Team).get(club.id)
-            if team is None:
-                team = Team()
-            team.id = club.id
-            team.name = club.name
-            team.leaderboard_exclude = club.id in config.OBSERVER_TEAMS
-            athlete_model.team = team
-            meta.scoped_session().add(team)
-            return team
-    finally:
-        meta.scoped_session().commit()
+        )
+    else:
+        club = matches[0]
+        # create the team row if it does not exist
+        team = meta.scoped_session().query(Team).get(club.id)
+        if team is None:
+            team = Team()
+        team.id = club.id
+        team.name = club.name
+        team.leaderboard_exclude = club.id in config.OBSERVER_TEAMS
+        athlete_model.team = team
+        meta.scoped_session().add(team)
+        return team

--- a/freezing/web/utils/auth.py
+++ b/freezing/web/utils/auth.py
@@ -11,7 +11,8 @@ from werkzeug.exceptions import Forbidden
 
 
 def login_athlete(strava_athlete):
-    session.permanent = True
+    # mobile devices delete transient cookies frequently so prefer a persistent cookie
+    session.permanent = True  # 128-day (see config) cookie instead of transient
     session["athlete_id"] = strava_athlete.id
     session["athlete_avatar"] = strava_athlete.profile_medium
     session["athlete_fname"] = strava_athlete.firstname


### PR DESCRIPTION
This rolls back athlete creation during login if the athlete is not valid, rather than leaving partial athletes committed. Best review with ignore whitespace. Can't test this locally because Strava auth to local is unlikely to be permitted.

Also bump session duration to the length of the competition.

Resolves #439 