### PR TITLE
Fix bandit GitHub Action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
 
@@ -50,13 +50,13 @@ jobs:
 
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         # Thanks https://stackoverflow.com/a/71854535/424301
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
@@ -65,7 +65,7 @@ jobs:
       -
         name: Build
         if: ${{ github.actor == 'dependabot[bot]' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           push: false
@@ -73,7 +73,7 @@ jobs:
       -
         name: Build and push
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: freezingsaddles/freezing-web/.github/workflows/build-docker.yml@1.5.6
+    uses: freezingsaddles/freezing-web/.github/workflows/build-docker.yml@881e148b972aea05878675367129720dee55e87e # 1.5.6
     concurrency: build-deploy-and-teset
     with:
       tag: latest
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: install
-        uses: appleboy/ssh-action@v1.1.0
+        uses: appleboy/ssh-action@25ce8cbbcb08177468c7ff7ec5cbfa236f9341e1 # v1.1.0
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
@@ -39,7 +39,7 @@ jobs:
             docker compose pull freezing-web
             docker compose up -d freezing-web
       - name: wait
-        uses: iFaxity/wait-on-action@v1.2.1
+        uses: iFaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866 # v1.2.1
         with:
           resource: https-get://freezingsaddles.org
           timeout: 5000
@@ -53,6 +53,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: test-wget-spider
         run: "URL=https://freezingsaddles.org test/wget-spider.sh"

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: freezingsaddles/freezing-web/.github/workflows/build-docker.yml@1.5.6
+    uses: freezingsaddles/freezing-web/.github/workflows/build-docker.yml@881e148b972aea05878675367129720dee55e87e # 1.5.6
     with:
       tag: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: freezingsaddles/freezing-web/.github/workflows/build-docker.yml@1.5.6
+    uses: freezingsaddles/freezing-web/.github/workflows/build-docker.yml@881e148b972aea05878675367129720dee55e87e # 1.5.6
     with:
       tag: latest-actions-build
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -23,17 +23,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install '.[dev]'
       - name: black Lint
-        uses: psf/black@24.1.1
+        uses: psf/black@e026c93888f91a47a9c9f4e029f3eb07d96375e6 # 24.1.1
       - name: isort Lint
-        uses: isort/isort-action@v1
+        uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # v1
         with:
           requirements-files: "pyproject.toml"
       - name: flake8 Lint
-        uses: py-actions/flake8@v2
+        uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # v2
         with:
           plugins: "flake8-pyproject"
       - name: lint - FawltyDeps
-        uses: tweag/FawltyDeps-action@608c1d70b1855183d84d3a3628f0ce8aa0005f46
+        uses: tweag/FawltyDeps-action@608c1d70b1855183d84d3a3628f0ce8aa0005f46 # 608c1d70b1855183d84d3a3628f0ce8aa0005f46
 
   templates:
     name: Templates Lint
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,10 +12,12 @@ jobs:
       security-events: write
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Perform Bandit Analysis
         uses: PyCQA/bandit-action@67a458d90fa11fb1463e91e7f4c8f068b5863c7f  # v1.0.1
         with:
           severity: "medium"
           confidence: "medium"
+          targets: "freezing tests"
+          skips: "B101"  # Skip assert statements check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,13 @@ repos:
     hooks:
       - id: check-undeclared
       - id: check-unused
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.1
+    hooks:
+      - id: bandit
+        # Skip B101 (assert_used) so tests can use bare asserts;
+        #   treat asserts as acceptable in test code.
+        # Provide args as separate tokens,
+        #   pre-commit does not split a single string.
+        args: ["--exit-zero", "-s", "B101", "-r", "src", "tests"]

--- a/README.md
+++ b/README.md
@@ -360,6 +360,29 @@ mysql> select a.name, sum(ds.distance), sum(ds.points) from daily_scores ds inne
 2 rows in set (0.02 sec)
 ```
 
+## Security
+
+### Bandit
+
+To scan for common security problems in the code, this uses [Bandit](https://bandit.readthedocs.io/en/latest/). To run the security linter, use this command:
+
+```bash
+bandit -s B101 -r freezing tests
+```
+
+This is integrated in GitHub Actions with the [PyCQA/bandit-action](https://github.com/PyCQA/bandit-action) which integrates with [GitHub Advanced Security](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-github-code-scanning).
+
+### GitHub actions version pinning
+
+Best security practices recommend [pinning versions of GitHub actions used in workflows to specific commit SHAs, to avoid supply chain attacks](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/). This project follows that practice.
+
+To make this easy, we use [mheap/pin-github-action](https://github.com/mheap/pin-github-action) via Docker to pin the versions of actions used in the workflows.
+
+```bash
+alias pin-github-action='docker run --rm -v $(pwd):/workflows -e GITHUB_TOKEN mheap/pin-github-action'
+pin-github-action .github/workflows
+```
+
 ## Legal
 
 This software is a community-driven effort, and as such the contributions are owned by the individual contributors:


### PR DESCRIPTION
This pull request introduces several improvements to the project's security and CI/CD processes. The most significant changes are the addition of Bandit security scanning, the adoption of best practices for GitHub Actions version pinning, and updates to workflow permissions for enhanced security. These changes are reflected in both configuration files and documentation.

**Security enhancements:**

* Added Bandit security scanning to CI via the `PyCQA/bandit-action` GitHub Action in `.github/workflows/security.yml`, with results integrated into GitHub Advanced Security. The configuration skips the B101 check to allow bare asserts in test code. [[1]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL8-R23) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R27-R36)
* Updated the `README.md` to document the use of Bandit for security scanning and to explain the rationale and usage of GitHub Actions version pinning for supply chain security.

**GitHub Actions workflow improvements:**

* All workflow files now pin third-party GitHub Actions to specific commit SHAs for improved supply chain security, following best practices. [[1]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fR31-R39) [[2]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL51-R59) [[3]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL66-R76) [[4]](diffhunk://#diff-b27178cc538468c70998f0ef6cc46dc7c330f852141bec96b069481d986d5fa2L12-R29) [[5]](diffhunk://#diff-b27178cc538468c70998f0ef6cc46dc7c330f852141bec96b069481d986d5fa2L38-R56) [[6]](diffhunk://#diff-1c86c1c8faa14669740bc58e2a70dde326fd3ae01a0ecf02d549e70191bcd48cL11-R13) [[7]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L8-R10) [[8]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R11-R47) [[9]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL8-R23)
* Added explicit `permissions: contents: read` (and `security-events: write` where needed) to all jobs in workflow files to restrict GitHub token permissions, reducing the risk of privilege escalation. [[1]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fR31-R39) [[2]](diffhunk://#diff-b27178cc538468c70998f0ef6cc46dc7c330f852141bec96b069481d986d5fa2L12-R29) [[3]](diffhunk://#diff-b27178cc538468c70998f0ef6cc46dc7c330f852141bec96b069481d986d5fa2L38-R56) [[4]](diffhunk://#diff-1c86c1c8faa14669740bc58e2a70dde326fd3ae01a0ecf02d549e70191bcd48cL11-R13) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L8-R10) [[6]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R11-R47) [[7]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL8-R23)

**Pre-commit hooks:**

* Integrated Bandit security checks into the pre-commit configuration, ensuring local code scans for vulnerabilities before commits.- **Switch to PyQCA/bandit-action**

Resolves  #485
