### PR TITLE
fix: handle ValueError on invalid ?limit= query parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /resources/docker/settings.cfg
 /src
 tmp.*
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ There is a sample file (`example.cfg`) that you can reference.  You need to set 
 Edit the file to change the value of `SECRET_KEY`, and set competition dates. Good date ranges are either the range for a prior year's competition, for testing with an archived database dump, or a 3 month range that includes the current date, for testing in conjunction with fresh data downloaded with [freezing-sync])https://github.com/freezingsaddles/freezing-sync)
 
 This component is designed to run as a container and should be configured with environment variables for:
+
 * `DEBUG`: Whether to display exception stack traces, etc.
 * `SECRET_KEY`: Used to cryptographically sign the Flask session cookies.
 * `SQLALCHEMY_URL`: The URL to the database.
@@ -112,6 +113,7 @@ This component is designed to run as a container and should be configured with e
 * `END_DATE`: The end of the competition.
 
 Changing _all_ these values is not necessary for a basic development setup. However, you should ensure these items are set appropriately:
+
 * The team IDs for the competition, `MAIN_TEAM`, `TEAMS` and any `OBSERVER_TEAMS`, if you are loading an archived database.
 * `SQLALCHEMY_URL` database credentials, if you are are using something other than the default Docker Compose setup.
 * Strava client API credentials, if you want to test athlete registration and authorization. (You don't have to do this to test user pages, see the [impersonation feature](https://github.com/freezingsaddles/freezing-web/pull/332))

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -6,3 +6,5 @@ echo "*** isort ***"
 isort freezing
 echo "*** djlint ***"
 djlint --reformat .
+echo "*** pymarkdown ***"
+pymarkdown fix .

--- a/freezing/web/views/api.py
+++ b/freezing/web/views/api.py
@@ -38,10 +38,15 @@ def get_limit(request):
     limit = request.args.get("limit")
     if limit is None:
         return config.TRACK_LIMIT_DEFAULT
-    limit = int(limit)
+    try:
+        limit = int(limit)
+    except ValueError:
+        abort(400, "limit must be an integer")
+    if limit < 1:
+        abort(400, "limit must be positive")
     if limit > config.TRACK_LIMIT_MAX:
         abort(400, f"limit {limit} exceeds {config.TRACK_LIMIT_MAX}")
-    return min(config.TRACK_LIMIT_MAX, int(limit))
+    return limit
 
 
 @blueprint.route("/stats/general")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,5 @@ ignore_unused = [
     "gunicorn",
     "isort",
     "pre-commit",
-    "pymarkdownlnt==0.9.37",
+    "pymarkdownlnt",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "flake8-pyproject",
     "isort",
     "pre-commit",
-    "pymarkdownlnt",
+    "pymarkdownlnt==0.9.37",
 ]
 runtime = [
     "gunicorn==23.0.0",
@@ -110,5 +110,5 @@ ignore_unused = [
     "gunicorn",
     "isort",
     "pre-commit",
-    "pymarkdownlnt",
+    "pymarkdownlnt==0.9.37",
 ]


### PR DESCRIPTION
## Problem

`_get_limit()` in `api.py` passed the `?limit=` query parameter directly 
to `int()` without error handling. A non-integer value like `?limit=abc` 
or `?limit=` caused an unhandled `ValueError`, returning a 500 server error 
instead of a meaningful 400 Bad Request.

This also bypassed the `TRACK_LIMIT_MAX` check entirely, creating a potential 
DoS vector noted in issue #310.

## Fix

- Wrapped `int(limit)` in `try/except ValueError`, returning `abort(400)`
- Added explicit check rejecting non-positive values (`limit < 1`)
- Removed redundant `int()` call on the return statement

## Testing

Tested locally with curl against a running dev server:
- `?limit=50` → 200 OK
- `?limit=abc` → 400 Bad Request  
- `?limit=0` → 400 Bad Request
- `?l